### PR TITLE
Updated incorrect description of routing.method

### DIFF
--- a/versioned_docs/version-2.0.0/reference/configs/schemas/Send.ts
+++ b/versioned_docs/version-2.0.0/reference/configs/schemas/Send.ts
@@ -186,8 +186,7 @@ export const routing: ApiParam = {
       required: true,
       enum: ["all", "single"],
       example: "single",
-      description:
-        "The method for selecting channels to send the message with. If no method is specified, then 'single' will be used as default.",
+      description: "The method for selecting channels to send the message with.",
     },
     {
       type: "array",


### PR DESCRIPTION
`routing.method`'s description implied that the field was optional when it is actually required.