### PR TITLE
Added timeout.channel and timeout.provider section

### DIFF
--- a/versioned_docs/version-2.0.0/reference/configs/schemas/Send.ts
+++ b/versioned_docs/version-2.0.0/reference/configs/schemas/Send.ts
@@ -451,6 +451,22 @@ export const timeout: ApiParam = {
       description:
         "An arbitrary duration for a message to be available for delivery. Default is 72 hours or 259200000 Milliseconds",
     },
+    {
+      type: "record",
+      name: "channel",
+      description: "An arbitrary duration for a channel to be available for delivery.",
+      field: {
+        type: "number",
+      },
+    },
+    {
+      type: "record",
+      name: "provider",
+      description: "An arbitrary duration for a provider to be available for delivery.",
+      field: {
+        type: "number",
+      },
+    },
   ],
 };
 


### PR DESCRIPTION
- This PR adds the `channel` and `provider` properties to the documentation for timeout