### PR TITLE
[C-6178] Fix Twilio Documentation Courier Auth Credentials Image

### DIFF
--- a/versioned_docs/version-2.0.0/guides/providers/sms/twilio.mdx
+++ b/versioned_docs/version-2.0.0/guides/providers/sms/twilio.mdx
@@ -169,7 +169,7 @@ Courier supports both basic and token authorization. For this tutorial, we will 
 We must send an `Authorization` header with each request. The Courier Send API also requires an `event`. The authorization token and event values are the "Auth Token" and "Notification ID" we see in the detail view of our “Test Appointment Reminder” event. Click the gear icon next to the Notification's name to reveal them.
 
 <Image
-  img={require("../../../assets/guides/twilio/auth-credentials.png")}
+  img={require("../../../assets/guides/twilio/courier-auth-credentials.png")}
   alt="Courier Authorization Credentials"
 />
 


### PR DESCRIPTION
Added prefix to correct image url link under "Authorization" at  https://www.courier.com/docs/guides/providers/sms/twilio/#send-a-message