### PR TITLE
[C-6529] Improvements to Elemental documentation

### DIFF
--- a/versioned_docs/version-2.0.0/elemental/elements.mdx
+++ b/versioned_docs/version-2.0.0/elemental/elements.mdx
@@ -142,7 +142,8 @@ Basic Usage:
 
 With raw:
 
-```json
+```js
+// Email
 {
   "type": "channel",
   "channel": "email",
@@ -154,6 +155,7 @@ With raw:
   }
 },
 
+// Slack
 {
   "type": "channel",
   "channel": "slack",
@@ -162,18 +164,17 @@ With raw:
   }
 },
 
+// Webhook
 {
-  "type": "channel", // all other channels
-  "elements": [
-    {
-      "type": "meta",
-      "title": "My Title"
-    },
-    {
-      "type": "text",
-      "content": "Hello **world**"
+  "type": "channel",
+  "channel": "webhook",
+  "raw": {
+    "payload": {
+      "body": {
+        "hello": "world"
+      }
     }
-  ]
+  }
 }
 ```
 

--- a/versioned_docs/version-2.0.0/elemental/intro.mdx
+++ b/versioned_docs/version-2.0.0/elemental/intro.mdx
@@ -28,3 +28,29 @@ All Courier Elemental templates have the following top level structure:
 | -------- | ---------------------------- | -------- | ------------------------------------- |
 | version  | string                       | required |                                       |
 | elements | [CourierElement](elements)[] | required | Array of [Courier Elements](elements) |
+
+## Usage
+
+Courier Elemental can be used in place of a standard template in a `/send` call. To do so,
+pass the elemental document as the `content` property of the message object:
+
+```js
+{
+  "message": {
+    "to": { /** etc */ },
+    "content":{
+      "elements": [
+        {
+          "type": "meta",
+          "title": "My Title"
+        },
+        {
+          "type": "text",
+          "content": "Hello **world**"
+        }
+      ],
+      "version": "2022-01-01",
+    }
+  }
+}
+```


### PR DESCRIPTION
Adds the following to elemental docs:
- Provides an example of defining a webhook 
- Adds example usage of elemental within a send call