### PR TITLE
[C-6658] Add "iOS (Swift, Obj-C)" to the client lib list

### DIFF
--- a/src/theme/sidebars.js
+++ b/src/theme/sidebars.js
@@ -70,6 +70,11 @@ module.exports = {
           label: "Ruby",
           href: "https://github.com/trycourier/courier-ruby",
         },
+        {
+          type: "link",
+          label: "iOS (Swift, Obj-C)",
+          href: "https://github.com/trycourier/courier-ios",
+        },
       ],
     },
     {

--- a/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/versioned_sidebars/version-2.0.0-sidebars.json
@@ -123,9 +123,9 @@
           "href": "https://github.com/trycourier/courier-ruby"
         },
         {
-          type: "link",
-          label: "iOS (Swift, Obj-C)",
-          href: "https://github.com/trycourier/courier-ios",
+          "type": "link",
+          "label": "iOS (Swift, Obj-C)",
+          "href": "https://github.com/trycourier/courier-ios"
         }
       ]
     },

--- a/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/versioned_sidebars/version-2.0.0-sidebars.json
@@ -121,6 +121,11 @@
           "type": "link",
           "label": "Ruby",
           "href": "https://github.com/trycourier/courier-ruby"
+        },
+        {
+          type: "link",
+          label: "iOS (Swift, Obj-C)",
+          href: "https://github.com/trycourier/courier-ios",
         }
       ]
     },


### PR DESCRIPTION
Add an entry for the iOS sdk linking to the iOS github page. I abbreviated Objective-C to Obj-C to keep the link text small in the sidebar.