### PR TITLE
Update roles-permissions.mdx

### DIFF
--- a/versioned_docs/version-2.0.0/getting-started/workspace-settings/roles-permissions.mdx
+++ b/versioned_docs/version-2.0.0/getting-started/workspace-settings/roles-permissions.mdx
@@ -33,7 +33,7 @@ Access to the data logs has three pre-defined levels
 :::
 
 - **Level 1:** View a list of messages with a high-level summary.
-- **Level 2:** View list of messages with high-level summary and message status details (received, sent, delivered).
+- **Level 2:** View list of messages with high-level summary and message status details (received, sent, delivered). Level 2 allows users to open the request received tab, which includes the profile data and their respective PII as well as any data passed via the request which may include PHI.
 - **Full Access:** List of messages in logs along with high-level summary, message status details (received, sent, delivered). Rendered message visible in Logs.
 
 | Role                   | Description                                                                                                    | Feature Access                                                                                                                                                    |


### PR DESCRIPTION
Added the following to clarify what level 2 logs access means: "Level 2 allows users to open the request received tab, which includes the profile data and their respective PII as well as any data passed via the request which could include PHI."